### PR TITLE
Fix longitude sync using ffprobe

### DIFF
--- a/include/ffprobe.php
+++ b/include/ffprobe.php
@@ -97,7 +97,7 @@ if (isset($general['tags']['location']))
 	$gps = (string)$general['tags']['location'];
 	$value = preg_split('/(\+|\-|\/)/', $gps, -1, PREG_SPLIT_DELIM_CAPTURE);
 	$exif['latitude'] = $value[1].$value[2];
-	$exif['longitude'] = $value[3].$value[4];
+	$exif['longitude'] = $value[3].rtrim($value[4],'/');
 }
 if (isset($general['tags']['major_brand']))
 {


### PR DESCRIPTION
ffprobe may provide the longitude value as:

  "
    location        : +60.1568+024.8577/
  "

Hence, this will result in a piwigo-videojs longitude value of:

  "
    longitude: +024.8577/
  "

That will lead to the following fatal error:

  "
    Fatal error: Uncaught mysqli_sql_exception: Data truncated for column 'longitude' at row 1 in /app/www/public/include/dblayer/functions_mysqli.inc.php:132 Stack trace: #0 /app/www/public/include/dblayer/functions_mysqli.inc.php(132): mysqli->query() #1 /config/www/plugins/piwigo-videojs/admin/admin_photo.php(126): pwg_query() #2 /app/www/public/admin/plugin.php(53): include_once('...') #3 /app/www/public/admin.php(345): include('...') #4 {main} thrown in /app/www/public/include/dblayer/functions_mysqli.inc.php on line 132
  "

Fixes: 5e9b209 (Add support for exiftool and ffprobe)
Closes: #167

Suggested-by: chrud