### PR TITLE
Workaround invalid dateTimeStamp returned by exif (fixes #133) (fixes #205)

### DIFF
--- a/include/function_sync2.php
+++ b/include/function_sync2.php
@@ -98,6 +98,11 @@ while ($row = pwg_db_fetch_assoc($result))
 				/* Save metadata */
 				if ($sync_options['metadata'] and !$sync_options['simulate'])
 				{
+					// Workaround invalid timestamp from exif
+					if ($exif['date_creation'] == '-0001-11-30 00:00:00') {
+						$exif['date_creation'] = '1990-01-01 00:00:00';
+					}
+
 					$dbfields = explode(",", "filesize,width,height,latitude,longitude,date_creation,rotation");
 					$query = "UPDATE ".IMAGES_TABLE." SET ".vjs_dbSet($dbfields, $exif).", `date_metadata_update`=CURDATE() WHERE `id`=".$row['id'].";";
 					//print $query;


### PR DESCRIPTION
Problem: My installation fails within the dblayer mentioning an invalid datetimestamp was requested to be written to the database.
Root cause: exif returned the wrong metadata.
Workaround: detect this and replace it by a db-valid pseudo-value.

Now my library of MP4 movies syncs fine.

ref #133 
ref #205