### PR TITLE
warn if generated poster file is 0 size

### DIFF
--- a/include/function_sync2.php
+++ b/include/function_sync2.php
@@ -192,6 +192,10 @@ while ($row = pwg_db_fetch_assoc($result))
                 {
                     $errors[] = "Error poster running ffmpeg/avconv, try it manually, check your webserver error log:\n<br/>". $ffmpeg;
                 }
+                else if (filesize($out) == 0)
+                {
+                    $warnings[] = "Poster for Movie ". $filename ." is zero bytes, likely due to video shorter than 1 sec \n<br/";
+                }
 				else
 				{/* We have a poster, lets update the DB */
 


### PR DESCRIPTION
This fixes a bug where `ffmpeg` produces 0 size .jpg/.png, but returns 0 status code.

This is the output from ffmpeg when the issue happens:
```
[out#0/rawvideo @ 0x6e9dc40] video:0KiB audio:0KiB subtitle:0KiB other streams:0KiB global headers:0KiB muxing overhead: unknown
[out#0/rawvideo @ 0x6e9dc40] Output file is empty, nothing was encoded(check -ss / -t / -frames parameters if used)
frame=    0 fps=0.0 q=0.0 Lsize=       0KiB time=N/A bitrate=N/A speed=N/A
```

tested on a 0.74 sec video w/
```
ffmpeg version 7.0.2-static https://johnvansickle.com/ffmpeg/  Copyright (c) 2000-2024 the FFmpeg developers
```

on Ubuntu 22.04
