### PR TITLE
Resize large videos to fit window frame

### DIFF
--- a/template/html5-player.tpl
+++ b/template/html5-player.tpl
@@ -5,7 +5,7 @@
 {/literal}{/html_head}
 
 {literal}
-<video id="my_video_1" class="video-js" {/literal}{$OPTIONS}{literal} poster={/literal}"{$VIDEOJS_POSTER_URL}"{literal} x-webkit-airplay="allow" width="auto" height="auto">
+<video id="my_video_1" class="video-js" {/literal}{$OPTIONS}{literal} poster={/literal}"{$VIDEOJS_POSTER_URL}"{literal} x-webkit-airplay="allow" width="100%" height="auto">
 {/literal}
 {if not empty($videos)}
 {foreach from=$videos item=video}


### PR DESCRIPTION
On mobile, when viewing a video wider than the screen, the video doesn't get resized to fit the screen.  Th

Tested w/ a 720p video.

If viewed on desktop and the video is smaller than the browser frame, it doens't upscale the video

Broken:
![bad](https://github.com/user-attachments/assets/2d2b47cb-eaad-4338-9368-746fcf7b6526)


Fixed:
![fixed](https://github.com/user-attachments/assets/8d713fa2-6580-48e7-bb83-9458490b22b0)
