### PR TITLE
Fix: Ensure VideoJS players are responsive and do not overflow on mobile

### DIFF
--- a/template/vjs-4-player.tpl
+++ b/template/vjs-4-player.tpl
@@ -26,17 +26,24 @@
 </script>
 <style>
 {literal}
-.video-js {padding-top: {/literal}{$RATIO}{literal}%}
-.vjs-fullscreen {padding-top: 0px}
-.videocontent{ width:80%; max-width:{/literal}{$WIDTH}{literal}px; margin: 0 auto;}
+.video-js {
+    padding-top: {/literal}{$RATIO}{literal}%; /* Server-side calculated aspect ratio */
+    width: 100% !important; /* Ensure it fills container */
+    height: 0 !important; /* Height is controlled by padding-top */
+}
+.vjs-fullscreen {padding-top: 0px !important;} /* Reset padding in fullscreen */
+.video-container {
+    width: 100%; /* Use full available width */
+    max-width: {/literal}{$WIDTH}{literal}px; /* Respect configured max width */
+    margin: 0 auto; /* Center the container */
+}
 {/literal}
 </style>
 {/html_head}
 
-<div class="wrapper">
- <div class="videocontent">
+<div class="video-container">
 {literal}
-<video id="my_video_1" class="video-js {/literal}{$VIDEOJS_SKIN}{literal}" {/literal}{$OPTIONS}{literal} poster={/literal}"{$VIDEOJS_POSTER_URL}"{literal} datasetup='{}' x-webkit-airplay="allow" width="auto" height="auto">
+<video id="my_video_1" class="video-js {/literal}{$VIDEOJS_SKIN}{literal}" {/literal}{$OPTIONS}{literal} poster={/literal}"{$VIDEOJS_POSTER_URL}"{literal} data-setup='{}' x-webkit-airplay="allow">
 {/literal}
 {if not empty($videos)}
 {foreach from=$videos item=video}
@@ -47,7 +54,6 @@
     <p>Video Playback Not Supported<br/>Your browser does not support the video tag.</p>
 </video>
 {/literal}
- </div>
 </div>
 
 {literal}

--- a/template/vjs-5-player.tpl
+++ b/template/vjs-5-player.tpl
@@ -22,10 +22,20 @@
 <script type="text/javascript">
   videojs.options.flash.swf = "{$VIDEOJS_PATH}video-js-5/video-js.swf"
 </script>
+<style>
+.video-js{ margin: 0 auto; }
+/* Ensure the video container takes up available width */
+.video-container {
+    width: 100%;
+    max-width: {$DERIV_MAX_WIDTH}px; /* Optional: if you still want a max width from config */
+    margin: 0 auto;
+}
+</style>
 {/html_head}
 
+<div class="video-container">
 {literal}
-<video id="my_video_1" class="video-js vjs-fluid vjs-big-play-centered {/literal}{$VIDEOJS_SKIN}{literal}" {/literal}{$OPTIONS}{literal} poster={/literal}"{$VIDEOJS_POSTER_URL}"{literal} datasetup='{}' x-webkit-airplay="allow">
+<video id="my_video_1" class="video-js vjs-fluid vjs-big-play-centered {/literal}{$VIDEOJS_SKIN}{literal}" {/literal}{$OPTIONS}{literal} poster={/literal}"{$VIDEOJS_POSTER_URL}"{literal} data-setup='{ "fluid": true }' x-webkit-airplay="allow">
 {/literal}
 {if not empty($videos)}
 {foreach from=$videos item=video}
@@ -36,6 +46,7 @@
     <p>Video Playback Not Supported<br/>Your browser does not support the video tag.</p>
 </video>
 {/literal}
+</div>
 
 {literal}
 <script type="text/javascript">

--- a/template/vjs-6-player.tpl
+++ b/template/vjs-6-player.tpl
@@ -1,10 +1,20 @@
 {html_head}
 <link href="{$VIDEOJS_PATH}video-js-6/video-js.min.css" rel="stylesheet">
 <script src="{$VIDEOJS_PATH}video-js-6/video.min.js"></script>
+<style>
+.video-js{ margin: 0 auto; }
+/* Ensure the video container takes up available width */
+.video-container {
+    width: 100%;
+    max-width: {$DERIV_MAX_WIDTH}px; /* Optional: if you still want a max width from config */
+    margin: 0 auto;
+}
+</style>
 {/html_head}
 
+<div class="video-container">
 {literal}
-<video id="my_video_1" class="video-js vjs-fluid vjs-default-skin" {/literal}{$OPTIONS}{literal} poster={/literal}"{$VIDEOJS_POSTER_URL}"{literal} datasetup='{}' x-webkit-airplay="allow">
+<video id="my_video_1" class="video-js vjs-fluid vjs-default-skin" {/literal}{$OPTIONS}{literal} poster={/literal}"{$VIDEOJS_POSTER_URL}"{literal} data-setup='{ "fluid": true }' x-webkit-airplay="allow">
 {/literal}
 {if not empty($videos)}
 {foreach from=$videos item=video}
@@ -15,6 +25,7 @@
     <p>Video Playback Not Supported<br/>Your browser does not support the video tag.</p>
 </video>
 {/literal}
+</div>
 
 {literal}
 <script type="text/javascript">

--- a/template/vjs-7-player.tpl
+++ b/template/vjs-7-player.tpl
@@ -3,11 +3,18 @@
 <script src="{$VIDEOJS_PATH}video-js-7/video.min.js"></script>
 <style>
 .video-js{ margin: 0 auto; }
+/* Ensure the video container takes up available width */
+.video-container {
+    width: 100%;
+    max-width: {$DERIV_MAX_WIDTH}px; /* Optional: if you still want a max width from config */
+    margin: 0 auto;
+}
 </style>
 {/html_head}
 
+<div class="video-container">
 {literal}
-<video id="my_video_1" class="video-js" {/literal}{$OPTIONS}{literal} poster={/literal}"{$VIDEOJS_POSTER_URL}"{literal} datasetup='{}' x-webkit-airplay="allow">
+<video id="my_video_1" class="video-js vjs-fluid" {/literal}{$OPTIONS}{literal} poster={/literal}"{$VIDEOJS_POSTER_URL}"{literal} data-setup='{ "fluid": true }' x-webkit-airplay="allow">
 {/literal}
 {if not empty($videos)}
 {foreach from=$videos item=video}
@@ -18,29 +25,19 @@
     <p>Video Playback Not Supported<br/>Your browser does not support the video tag.</p>
 </video>
 {/literal}
+</div>
 
 {footer_script}
 {literal}
-function setVideoDimensions(player, i) {
-    let dim = player.currentDimensions();
-    if (dim.height == 150 && dim.width == 300 && i > 0) {   /* default dimensions => retry in 50 milliseconds */
-        setTimeout(setVideoDimensions, 50, player, i - 1);
-    } else {
-        let max_height = {/literal}{$DERIV_MAX_HEIGHT}{literal};
-        let max_width = {/literal}{$DERIV_MAX_WIDTH}{literal};
-        if ( dim.height > max_height || dim.width > max_width ) {
-            if ( dim.height > 0 && dim.width > 0 ) {
-                let scale = Math.min( max_height / dim.height, max_width / dim.width );
-                player.width(Math.floor( scale * dim.width ));
-            };
-        };
-    };
-};
+// const player = videojs("my_video_1"); // Video.js will auto-initialize with data-setup
 
-const player = videojs("my_video_1");
-
-player.ready(function(){
-    setVideoDimensions(player, 20);
-});
+// player.ready(function(){
+    // Custom dimension logic removed to allow vjs-fluid to work.
+    // If specific max dimensions are still strictly needed,
+    // they should ideally be handled by the container's CSS.
+    // let max_height = {/literal}{$DERIV_MAX_HEIGHT}{literal};
+    // let max_width = {/literal}{$DERIV_MAX_WIDTH}{literal};
+    // console.log("Video.js player ready. Max dimensions (config): " + max_width + "x" + max_height);
+// });
 {/literal}
 {/footer_script}


### PR DESCRIPTION
Applied responsive fixes to Video.js templates (v4, v5, v6, v7) and reviewed the HTML5 player template.

- Modified v7, v6, v5 players to use a consistent `.video-container` div, ensuring they take full available width up to a configured max-width.
- Leveraged the `vjs-fluid` class and explicit `data-setup='{ "fluid": true }'` for these versions.
- Removed custom JavaScript sizing logic from v7 player, relying on Video.js's built-in fluid handling.
- Adjusted v4 player's CSS to use `width: 100%` for its container and ensured its existing aspect ratio logic correctly fills this container.
- Verified the HTML5 player template already uses appropriate responsive attributes and styles.